### PR TITLE
docs: Add README with action summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Audio Switcher
+
+A StreamController plugin for managing audio output devices on Linux using PulseAudio.
+
+## Actions
+
+### Set Device
+Sets the default audio output to a specific configured device and port.
+
+### Toggle Output
+Toggles between two pre-configured audio output devices with optional port selection.


### PR DESCRIPTION
## Summary

This PR adds a README file that documents the AudioSwitcher plugin and provides one-sentence summaries of each available action:

- **Set Device**: Sets the default audio output to a specific configured device and port
- **Toggle Output**: Toggles between two pre-configured audio output devices with optional port selection

This documentation will help users understand what each action does without needing to explore the code or trial and error.